### PR TITLE
fix(iter): chunk_by with early break

### DIFF
--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -1063,39 +1063,25 @@ pub fn Iter::chunk_by[T, K : Eq](
   f : (T) -> K
 ) -> Iter[(K, Iter[T])] {
   fn(yield_) {
-    let mut has_current = false
     let mut current_key : K? = None
     let mut buffer : Array[T] = []
-    fn emit_current_chunk() -> IterResult {
-      if buffer.is_empty() {
-        return IterContinue
-      }
-      let key = current_key.unwrap()
-      let elements = buffer
-      buffer = Array::new(capacity=16)
-      yield_((key, elements.iter()))
-    }
-
-    self.run(fn(x) {
+    for x in self {
       let key = f(x)
-      if has_current && key == current_key.unwrap() {
-        buffer.push(x)
-        IterContinue
-      } else {
-        if has_current {
-          if emit_current_chunk() == IterEnd {
-            return IterEnd
+      match current_key {
+        None => current_key = Some(key)
+        Some(old_key) =>
+          if key != old_key {
+            guard yield_((old_key, buffer.iter())) is IterContinue else {
+              return IterEnd
+            }
+            buffer = Array::new(capacity=16)
+            current_key = Some(key)
           }
-        }
-        has_current = true
-        current_key = Some(key)
-        buffer.push(x)
-        IterContinue
       }
-    })
-    |> ignore
-    if has_current {
-      emit_current_chunk()
+      buffer.push(x)
+    }
+    if current_key is Some(old_key) {
+      yield_((old_key, buffer.iter()))
     } else {
       IterContinue
     }

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -874,6 +874,18 @@ test "chunk_by with custom key function" {
 }
 
 ///|
+test "chunk_by with break" {
+  let iter = [1, 2].iter()
+  let chunked = iter.chunk_by(fn(x) { x }).append((3, [3].iter()))
+  let mut c = 0
+  for _ in chunked {
+    c += 1
+    break
+  }
+  assert_eq!(c, 1)
+}
+
+///|
 test "chunk_by with strings" {
   let iter = ["apple", "avocado", "banana", "cherry", "blueberry"].iter()
   let chunked = iter.chunk_by(fn(s) { s[0] })


### PR DESCRIPTION
1. If the result is `IterEnd`, it should return `IterEnd` immediately, signifying that the for loop exited due to a `break`.

2. `has_current` is true if and only if `current_key` is `Some(_)`, so it is unnecessary.